### PR TITLE
improve block styling

### DIFF
--- a/src/documentRenderers/richtext/RichTextRenderer.css
+++ b/src/documentRenderers/richtext/RichTextRenderer.css
@@ -1,14 +1,8 @@
-.react-renderer {
-  margin: 0.5rem;
-}
-
 /*For the text inside the Node View Content*/
 [data-node-view-content] > div {
   display: block;
-  padding: 0.5rem;
-  margin: 0 0 0 2rem;
-  background: #eeeeee; /* TEMP, TODO */
-  border-radius: 0.5rem; /* TEMP, TODO */
+  margin: 0;
+  /* background: #eeeeee;  */
 }
 
 .ProseMirror p.is-empty::before {
@@ -35,4 +29,8 @@
   border: 1px solid #262626;
   border-radius: 5px;
   background-color: #262626;
+}
+
+blockquote {
+  margin: 0;
 }

--- a/src/documentRenderers/richtext/RichTextRenderer.tsx
+++ b/src/documentRenderers/richtext/RichTextRenderer.tsx
@@ -113,7 +113,7 @@ const RichTextRenderer: React.FC<Props> = (props) => {
   });
 
   return (
-    <div style={{ maxWidth: 600, margin: "0 auto" }}>
+    <div>
       {editor != null ? <InlineMenu editor={editor} /> : null}
       <EditorContent editor={editor} />
     </div>

--- a/src/documentRenderers/richtext/extensions/blocktypes/Block.module.css
+++ b/src/documentRenderers/richtext/extensions/blocktypes/Block.module.css
@@ -1,40 +1,60 @@
 .block {
-    display: block;
-    padding: 0;
-    margin: 0 2rem 0 0;
+  display: block;
+  /* use padding instead of margin. 
+  We want blocks to be adjacent, 
+  so that drag-handle never dissappears when moving vertically 
+  but instantly moves to next element */
+  padding: 0.5rem 0;
+}
+
+.inner {
+  max-width: 600px;
+  margin: 0 auto;
+  min-height: 1rem; /* same as .handle height */
+}
+
+.handleContainer {
+  position: absolute;
+}
+
+.block p {
+  margin: 0;
 }
 
 .handle {
-    display: flex;
-    position: absolute;
-    width: 1rem;
-    height: 1rem;
-    margin: 0.5rem;
-    cursor: grab;
-    background-image: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 16"><path fill-opacity="0.2" d="M4 14c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zM2 6C.9 6 0 6.9 0 8s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6C.9 0 0 .9 0 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" /></svg>');
-    background-repeat: no-repeat;
-    background-size: contain;
-    background-position: center;
+  display: none;
+  left: -20px;
+  top: 1px;
+  position: relative;
+  width: 1rem;
+  height: 1rem;
+  cursor: grab;
+  background-image: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 16"><path fill-opacity="0.2" d="M4 14c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zM2 6C.9 6 0 6.9 0 8s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6C.9 0 0 .9 0 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" /></svg>');
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center;
 }
 
-.outer {
-    display: flex;
-    position: absolute;
-    width: 1rem;
-    height: 1rem;
-    margin: 0.5rem 0.5rem 0.5rem 0.5rem;
-    cursor: grab;
-    background-image: url('data:image/svg+xml;charset=UTF-8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 16"><path fill-opacity="0.2" d="M4 14c0 1.1-.9 2-2 2s-2-.9-2-2 .9-2 2-2 2 .9 2 2zM2 6C.9 6 0 6.9 0 8s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0-6C.9 0 0 .9 0 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm6 4c1.1 0 2-.9 2-2s-.9-2-2-2-2 .9-2 2 .9 2 2 2zm0 2c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2zm0 6c-1.1 0-2 .9-2 2s.9 2 2 2 2-.9 2-2-.9-2-2-2z" /></svg>');
-    background-repeat: no-repeat;
-    background-size: contain;
-    background-position: center;
-}
-
-.react-renderer {
-    margin: 0.7rem;
+.block:hover .handle {
+  display: block;
 }
 
 img {
-    display: block;
-    max-width: 100%;
+  display: block;
+  max-width: 100%;
+}
+
+.content {
+}
+blockquote.content {
+  padding: 0.5rem 1rem;
+}
+
+blockquote.content p {
+  padding: 0.5rem 0;
+}
+
+hr.content {
+  position: relative;
+  top: 0.5rem; /* half of handle height */
 }

--- a/src/documentRenderers/richtext/extensions/blocktypes/Block.tsx
+++ b/src/documentRenderers/richtext/extensions/blocktypes/Block.tsx
@@ -33,26 +33,34 @@ function Block(type: ElementType) {
 
     return (
       <NodeViewWrapper className={styles.block}>
-        <Tippy
-          content={<SideMenu onDelete={onDelete}></SideMenu>}
-          trigger={"click"}
-          placement={"left"}
-          interactive={true}>
-          <div
-            className={styles.handle}
-            contentEditable="false"
-            unselectable="on"
-            draggable="true"
-            data-drag-handle // Ensures that the element can only be dragged using the drag handle.
-          />
-        </Tippy>
-        {type === "code" ? ( // Wraps content in "pre" tags if the content is code.
-          <pre>
-            <NodeViewContent className={styles.content} as={type} />
-          </pre>
-        ) : (
-          <NodeViewContent className={styles.content} as={type} />
-        )}
+        <div className={styles.inner}>
+          <div className={styles.handleContainer}>
+            <Tippy
+              content={<SideMenu onDelete={onDelete}></SideMenu>}
+              trigger={"click"}
+              placement={"left"}
+              interactive={true}>
+              <div
+                className={styles.handle}
+                contentEditable="false"
+                unselectable="on"
+                draggable="true"
+                data-drag-handle // Ensures that the element can only be dragged using the drag handle.
+              />
+            </Tippy>
+          </div>
+          {type === "code" ? ( // Wraps content in "pre" tags if the content is code.
+            <pre>
+              <NodeViewContent className={styles.content} as={type} />
+            </pre>
+          ) : (
+            <NodeViewContent
+              contentEditable={true}
+              className={styles.content}
+              as={type}
+            />
+          )}
+        </div>
       </NodeViewWrapper>
     );
   };


### PR DESCRIPTION
Fancy block / handle styling and hover to show handle:

![styles](https://user-images.githubusercontent.com/368857/118277352-00d02800-b4c9-11eb-9009-d7e2ee369d2c.gif)

Known issues:
- navigating away with keyboard should make draghandle dissappear. Currently it's only affected by mouse hovering. I'll probably create a separate issue for this
- List elements, I'll look into this next
