### PR TITLE
fix heading bug

### DIFF
--- a/src/documentRenderers/richtext/extensions/blocktypes/CustomReactNodeViewRenderer.ts
+++ b/src/documentRenderers/richtext/extensions/blocktypes/CustomReactNodeViewRenderer.ts
@@ -7,7 +7,7 @@ export function CustomReactNodeViewRenderer(component: any, options?: any) {
     if (oldUpdate) {
       renderer.update = function () {
         let ret = oldUpdate.apply(this, arguments);
-        this.contentDOM; // trigger fix
+        let fix = this.contentDOM; // trigger fix
         return ret;
       };
     }

--- a/src/documentRenderers/richtext/extensions/blocktypes/index.ts
+++ b/src/documentRenderers/richtext/extensions/blocktypes/index.ts
@@ -28,7 +28,9 @@ export function extendAsBlock(
     addNodeView() {
       // TODO? If we don't have a block-id, we don't really need the node-view wrapper with all corresponding <div>s
       // https://github.com/YousefED/typecell-next/issues/57
-      return ReactNodeViewRenderer(Block(this.type.spec.toDOM!, this.options));
+      return CustomReactNodeViewRenderer(
+        Block(this.type.spec.toDOM!, this.options)
+      );
     },
 
     addKeyboardShortcuts() {


### PR DESCRIPTION
fixes #74  .

I've nailed it down to an error in the TipTap NodeViewRenderer. (basically the contentDOM element doesn't get assigned to the right parent at the right time).

This is a hotfix but I'd rather not have it merged, and fix the issue in TipTap instead. https://github.com/ueberdosis/tiptap/issues/1370

They might need a small CodeSandbox to reproduce the issue, but let's wait for their reaction first