### PR TITLE
fix keyboard navigation, simplify divs

### DIFF
--- a/src/documentRenderers/richtext/extensions/blocktypes/Block.module.css
+++ b/src/documentRenderers/richtext/extensions/blocktypes/Block.module.css
@@ -49,6 +49,9 @@
   bottom: 0;
   width: 100vw;
   z-index: 1;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  user-select: none;
 }
 
 .codeBlockLanguageSelector {

--- a/src/documentRenderers/richtext/extensions/blocktypes/Block.tsx
+++ b/src/documentRenderers/richtext/extensions/blocktypes/Block.tsx
@@ -21,6 +21,7 @@ import TypeCellComponent from "../typecellnode/TypeCellComponent";
 import SideMenu from "../../menus/SideMenu";
 import mergeAttributesReact from "../../util/mergeAttributesReact";
 import styles from "./Block.module.css";
+import { CustomNodeViewWrapper } from "./CustomNodeViewWrapper";
 /**
  * A global store that keeps track of which block is being hovered over
  */
@@ -274,42 +275,46 @@ function Block(
       : {};
 
     return (
-      <NodeViewWrapper className={`${styles.block}`}>
-        <div ref={outerRef}>
-          <div className={styles.inner + " inner"} ref={innerRef}>
-            <div className={styles.handleContainer} ref={dragRef}>
-              <Tippy
-                content={<SideMenu onDelete={onDelete}></SideMenu>}
-                trigger={"click"}
-                placement={"left"}
-                interactive={true}>
-                <div
-                  contentEditable={false} // This is needed because otherwise pressing key up when positioned just after draghandle doesn't work
-                  className={styles.handle + (hover ? " " + styles.hover : "")}
-                />
-              </Tippy>
-            </div>
-            {renderContentBasedOnDOMType(
-              domType,
-              domAttrs,
-              placeholderAttrs,
-              props
-            )}
-          </div>
+      <CustomNodeViewWrapper className={`${styles.block}`} ref={outerRef}>
+        <div className={styles.inner + " inner"} ref={innerRef}>
           <div
-            className={`${styles.mouseCapture} ${
-              hover && canDrop
-                ? " " +
-                  (globalState.aboveCenterLine
-                    ? styles.topIndicator
-                    : styles.bottomIndicator)
-                : ""
-            }`}
-            onMouseOver={onMouseOver}
-            ref={mouseCaptureRef}
-            contentEditable={false}></div>
+            className={styles.handleContainer}
+            ref={dragRef}
+            // This is needed because otherwise pressing key up when positioned just after draghandle doesn't work
+            contentEditable={false}>
+            <Tippy
+              content={<SideMenu onDelete={onDelete}></SideMenu>}
+              trigger={"click"}
+              placement={"left"}
+              interactive={true}>
+              <div
+                className={
+                  styles.handle + (hover ? " " + styles.hover : "")
+                }></div>
+            </Tippy>
+          </div>
+          {renderContentBasedOnDOMType(
+            domType,
+            domAttrs,
+            placeholderAttrs,
+            props
+          )}
         </div>
-      </NodeViewWrapper>
+        <div
+          className={`${styles.mouseCapture} ${
+            hover && canDrop
+              ? " " +
+                (globalState.aboveCenterLine
+                  ? styles.topIndicator
+                  : styles.bottomIndicator)
+              : ""
+          }`}
+          onMouseOver={onMouseOver}
+          ref={mouseCaptureRef}
+          contentEditable={false}>
+          {/* space content is needed because otherwise keyboard navigation doesn't work well */}{" "}
+        </div>
+      </CustomNodeViewWrapper>
     );
   });
 }
@@ -357,19 +362,13 @@ function renderContentBasedOnDOMType(
       </pre>
     );
   } else if (props.node.type.name === "typecell") {
-    return (
-      <div>
-        <TypeCellComponent node={props.node}></TypeCellComponent>
-      </div>
-    );
+    return <TypeCellComponent node={props.node}></TypeCellComponent>;
   } else {
     return (
-      <div>
-        <NodeViewContent
-          as={domType}
-          {...mergeAttributesReact(placeholderAttrs, domAttrs)}
-        />
-      </div>
+      <NodeViewContent
+        as={domType}
+        {...mergeAttributesReact(placeholderAttrs, domAttrs)}
+      />
     );
   }
 }

--- a/src/documentRenderers/richtext/extensions/blocktypes/CustomNodeViewWrapper.tsx
+++ b/src/documentRenderers/richtext/extensions/blocktypes/CustomNodeViewWrapper.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+export interface NodeViewWrapperProps {
+  [key: string]: any;
+  as?: React.ElementType;
+}
+
+// delete this file when merged into tiptap: https://github.com/ueberdosis/tiptap/pull/1452
+export const CustomNodeViewWrapper: React.FC<NodeViewWrapperProps> =
+  React.forwardRef((props, ref) => {
+    //   const { onDragStart } = useReactNodeView()
+    const Tag = props.as || "div";
+
+    return (
+      <Tag
+        {...props}
+        data-node-view-wrapper=""
+        //   onDragStart={onDragStart}
+        style={{
+          ...props.style,
+          whiteSpace: "normal",
+        }}
+        ref={ref}
+      />
+    );
+  });


### PR DESCRIPTION
This should fix the arrow key navigation for normal blocks (not for typecell blocks).

Main fixes were:
- move contenteditable=false one layer up
- add a space in the mouseCaptureRef (and set selectable none to make sure it doesn't show up when selecting multiple blocks)

I've also taken the opportunity to clean up several (afaik) unnecessary divs.

@pvunderink @matthewlipski can you check whether this seems more stable than before? So not only arrow key navigation, but also slash menu, drag / drop, etc?

If so then I think we should merge it soon (I merged from typecell-tiptap so that's not ideal though)

PS: The github diff shows many lines changed, but that's mainly because of an indentation change (removed an outer element)

fixes https://github.com/YousefED/typecell-next/issues/73 (@pvunderink would this PR also fix other outstanding issues? does it also relate to the heading bug?)