### PR TITLE
Fix testing setup

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,8 @@
 {
   // See http://go.microsoft.com/fwlink/?LinkId=827846
   // for the documentation about the extensions.json format
-  "recommendations": ["esbenp.prettier-vscode"]
+  "recommendations": [
+    "esbenp.prettier-vscode",
+    "orta.vscode-jest"
+  ]
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  preset: "ts-jest",
+};

--- a/package.json
+++ b/package.json
@@ -105,8 +105,14 @@
   },
   "jest": {
     "transformIgnorePatterns": [
-      "/node_modules/(?!monaco-editor).+\\.js$"
-    ]
+      "/node_modules/(?!monaco-editor).+\\.js$",
+      "/node_modules/y-monaco/.+\\.js$"
+    ],
+    "moduleNameMapper": {
+      "lib0/dist/(.+)\\.js$": "<rootDir>/node_modules/lib0/dist/$1.cjs",
+      "y-protocols/(.+)\\.js$": "<rootDir>/node_modules/y-protocols/dist/$1.cjs",
+      "monaco-editor$": "<rootDir>/src/__mocks__/monacoMock.ts"
+    }
   },
   "devDependencies": {
     "@svgr/webpack": "^5.5.0",

--- a/src/__mocks__/monacoMock.ts
+++ b/src/__mocks__/monacoMock.ts
@@ -1,0 +1,17 @@
+// mock necessary for monaco
+Object.defineProperty(window, "matchMedia", {
+  writable: true,
+  value: (query: any) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: jest.fn(), // Deprecated
+    removeListener: jest.fn(), // Deprecated
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+    dispatchEvent: jest.fn(),
+  }),
+});
+
+// import "monaco-editor" doesn't work in jest
+export * from "monaco-editor/esm/vs/editor/editor.api.js";

--- a/src/sandbox/__tests__/diffToMonacoTextEdits.test.ts
+++ b/src/sandbox/__tests__/diffToMonacoTextEdits.test.ts
@@ -1,20 +1,4 @@
-// mock necessary for monaco
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: (query: any) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: jest.fn(), // Deprecated
-    removeListener: jest.fn(), // Deprecated
-    addEventListener: jest.fn(),
-    removeEventListener: jest.fn(),
-    dispatchEvent: jest.fn(),
-  }),
-});
-
-// import "monaco-editor" doesn't work in jest
-import * as monaco from "monaco-editor/esm/vs/editor/editor.api.js";
+import * as monaco from "monaco-editor";
 import { diffToMonacoTextEdits } from "../diffToMonacoTextEdits";
 
 function applyTest(v1: string, v2: string) {
@@ -24,7 +8,6 @@ function applyTest(v1: string, v2: string) {
   expect(model.getValue()).toEqual(v2);
   return edits;
 }
-
 it("basic replace", () => {
   const edits = applyTest("hello", "hi");
   expect(edits).toHaveLength(1);


### PR DESCRIPTION
This should fix npm test. Both monaco-editor and yjs use esm modules by default, which jest doesn't support.

This is a workaround.

References: https://github.com/react-monaco-editor/react-monaco-editor/issues/176

PS: I've added the jest vscode extension as recommended extension. I'd suggest installing it as it makes working with tests in vs code a lot easier