### PR TITLE
small bug fixes, better nodeview handling

### DIFF
--- a/src/documentRenderers/richtext/RichTextRenderer.tsx
+++ b/src/documentRenderers/richtext/RichTextRenderer.tsx
@@ -188,7 +188,6 @@ const RichTextRenderer: React.FC<Props> = observer((props: Props) => {
       {editor != null ? (
         <CommentWrapper editor={editor} commentStore={commentStore} />
       ) : null}
-      <EditorContent editor={editor} />
       <EngineContext.Provider value={{ engine, document: props.document }}>
         <EditorContent editor={editor} />
       </EngineContext.Provider>

--- a/src/documentRenderers/richtext/extensions/blocktypes/Block.tsx
+++ b/src/documentRenderers/richtext/extensions/blocktypes/Block.tsx
@@ -55,6 +55,22 @@ function Block(
   return observer(function Component(
     props: PropsWithChildren<NodeViewRendererProps>
   ) {
+    // The node is not supposed to be draggable, for example, we could be dealing with a paragraph
+    // inside a <li> or <blockquote>. In that case, the wrapper should be draggable, not this item itself.
+    if (!props.node.attrs["block-id"]) {
+      // this should be covered by disabling the nodeview in addNodeView
+      throw new Error("unexpected, no block id");
+      // return (
+      //   <NodeViewWrapper>
+      //     <NodeViewContent
+      //       as={domType}
+      //       {...domAttrs}
+      //       ref={(props as any).contentWrapperRef}
+      //     />
+      //   </NodeViewWrapper>
+      // );
+    }
+
     const domOutput = toDOM(props.node);
     // NOTE: we might want to extend ElementType itself instead of declaring it like this
     let domType: ElementType | "typecell";
@@ -205,20 +221,6 @@ function Block(
       }),
       [props.getPos, props.node]
     );
-
-    // The node is not supposed to be draggable, for example, we could be dealing with a paragraph
-    // inside a <li> or <blockquote>. In that case, the wrapper should be draggable, not this item itself.
-    if (!props.node.attrs["block-id"]) {
-      return (
-        <NodeViewWrapper>
-          <NodeViewContent
-            as={domType}
-            {...domAttrs}
-            ref={(props as any).contentWrapperRef}
-          />
-        </NodeViewWrapper>
-      );
-    }
 
     function onDelete() {
       if (typeof props.getPos === "boolean") {

--- a/src/documentRenderers/richtext/extensions/typecellnode/TypeCellComponent.tsx
+++ b/src/documentRenderers/richtext/extensions/typecellnode/TypeCellComponent.tsx
@@ -1,4 +1,3 @@
-import { NodeViewWrapper } from "@tiptap/react";
 import { useContext } from "react";
 import NotebookCell from "../../../notebook/NotebookCell";
 import { EngineContext } from "./EngineContext";


### PR DESCRIPTION
This addresses several issues:

- don't render nodeview when we don't have block-id (fixes #57). This was not causing any issues, but is more a cleanup that was already pending. It might cause new issues, but that's why we're merging this before extensive testing this week (so we notice it in time)
- Fix a merge error in richtextrenderer.tsx (duplicate editor content)
- Better handling of stopEvent. Our previous `stopEvent: (event) => true` helped to prevent a lot of tiptap logic that was causing issues (not being able to click on drag handles for example), but was a bit too naive. Now, events within the contentDom are passed to PM again, which should fix like pasting, etc.