### PR TITLE
Fix command menu bug #178

### DIFF
--- a/src/documentRenderers/richtext/prosemirrorPlugins/suggestions/SuggestionPlugin.ts
+++ b/src/documentRenderers/richtext/prosemirrorPlugins/suggestions/SuggestionPlugin.ts
@@ -111,8 +111,6 @@ export function SuggestionPlugin<T extends SuggestionItem>({
       // prevent blurring when clicking with the mouse inside the popup menu
       const blurMeta = transaction.getMeta("blur");
       if (blurMeta?.event.relatedTarget) {
-        console.log(blurMeta?.event.relatedTarget);
-
         const c = renderer.getComponent();
         if (c?.contains(blurMeta.event.relatedTarget)) {
           return false;


### PR DESCRIPTION
Fixes bug from issue #178: the command menu closes unexpectedly when the user clicks on the scrollbar. 