### PR TITLE
Fix: Change the color of background inside code blocks

### DIFF
--- a/src/documentRenderers/richtext/extensions/blocktypes/Block.module.css
+++ b/src/documentRenderers/richtext/extensions/blocktypes/Block.module.css
@@ -123,6 +123,10 @@
   background-color: #aad2ff;
 }
 
+code ::selection {
+  background-color: #808080;
+}
+
 :global(div[data-reference-hidden]) {
   visibility: hidden !important;
 }


### PR DESCRIPTION
A gray background of selected text inside code blocks provides better readability. No other bugs are found except those fixed last week. 