### PR TITLE
forward models in bulk

### DIFF
--- a/packages/editor/src/runtime/executor/executionHosts/sandboxed/SandboxedExecutionHost.tsx
+++ b/packages/editor/src/runtime/executor/executionHosts/sandboxed/SandboxedExecutionHost.tsx
@@ -21,10 +21,11 @@ let ENGINE_ID = 0;
 const FREEZE_TIMEOUT = 3000;
 export default class SandboxedExecutionHost
   extends lifecycle.Disposable
-  implements ExecutionHost {
+  implements ExecutionHost
+{
   public readonly iframe: HTMLIFrameElement;
   private disposed: boolean = false;
-  private resetHovering = () => { };
+  private resetHovering = () => {};
 
   private readonly connection: Connection<FrameConnection["methods"]>;
   private connectionMethods:
@@ -86,7 +87,10 @@ export default class SandboxedExecutionHost
       "geolocation; microphone; camera; midi; encrypted-media; autoplay; accelerometer; magnetometer; gyroscope; vr";
     iframe.allowFullscreen = true;
     iframe.src =
-      window.location.protocol + "//" + getFrameDomain() + "/?frame" +
+      window.location.protocol +
+      "//" +
+      getFrameDomain() +
+      "/?frame" +
       "&documentId=" +
       encodeURIComponent(documentId) +
       (window.location.search.includes("noRun") ? "&noRun" : "");
@@ -109,7 +113,7 @@ export default class SandboxedExecutionHost
     // });
 
     this.initialize().then(
-      () => { },
+      () => {},
       (e) => {
         console.error(e);
       }

--- a/packages/editor/src/runtime/executor/executionHosts/sandboxed/iframesandbox/FrameConnection.ts
+++ b/packages/editor/src/runtime/executor/executionHosts/sandboxed/iframesandbox/FrameConnection.ts
@@ -26,14 +26,13 @@ export class FrameConnection extends lifecycle.Disposable {
     deep: false,
   });
 
-  public readonly modelPositions =
-    observable.map<
-      string,
-      {
-        x: number;
-        y: number;
-      }
-    >();
+  public readonly modelPositions = observable.map<
+    string,
+    {
+      x: number;
+      y: number;
+    }
+  >();
 
   constructor() {
     super();
@@ -102,21 +101,32 @@ export class FrameConnection extends lifecycle.Disposable {
   }
 
   private methods = {
+    updateModels: async (
+      bridgeId: string,
+      models: { modelId: string; model: { value: string } }[]
+    ) => {
+      for (let model of models) {
+        await this.methods.updateModel(bridgeId, model.modelId, model.model);
+      }
+    },
     updateModel: async (
       bridgeId: string,
       modelId: string,
       model: { value: string }
     ) => {
+      console.log("register model", modelId);
       const modelReceiver = this.modelReceivers.get(bridgeId);
       if (modelReceiver) {
         if (bridgeId === "main" && !this.modelPositions.has(modelId)) {
-          this.modelPositions.set(
-            modelId,
-            observable({
-              x: 0,
-              y: 0,
-            })
-          );
+          runInAction(() => {
+            this.modelPositions.set(
+              modelId,
+              observable({
+                x: 0,
+                y: 0,
+              })
+            );
+          });
         }
         modelReceiver.updateModel(modelId, model);
       } else {


### PR DESCRIPTION
This prevents models being registered 1-by-1 to the iframe, which would then trigger a dimension update on the host after every registration, which subsequently triggered a position update on the client of other (unregistered) models