### PR TITLE
add ci flag to lerna

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "--postinstall": "npm run bootstrap && patch-package",
-    "bootstrap": "lerna bootstrap --hoist && patch-package",
+    "bootstrap": "lerna bootstrap --hoist --ci && patch-package",
     "test": "jest --coverage=true --config=jest.config.js && lerna run test-no-watch",
     "build": "lerna run build --concurrency 1",
     "build-react": "lerna run build-react --concurrency 1 --stream",


### PR DESCRIPTION
On `npm run bootstrap`, lerna automatically updates dependencies instead of respecting the lock file. This would cause for example TipTap to upgrade without intending to do so (@pvunderink was running into this).

Adding this flag should be a workaround.

See also https://github.com/lerna/lerna/issues/2447#issuecomment-681626733