### PR TITLE
Remove debugger statement and disable runtime error reporting

### DIFF
--- a/packages/editor/src/index.tsx
+++ b/packages/editor/src/index.tsx
@@ -27,7 +27,7 @@ if (process.env.NODE_ENV === "development") {
   // user-defined react components. It's annoying (and slow) to get the React error overlay
   // while editing TypeCell cells
   // Note that this breaks hot reloading
-  // (reo as any).stopReportingRuntimeErrors();
+  (reo as any).stopReportingRuntimeErrors();
 }
 
 // const config = {

--- a/packages/editor/src/runtime/editor/languages/typescript/typeAcquisition.ts
+++ b/packages/editor/src/runtime/editor/languages/typescript/typeAcquisition.ts
@@ -181,7 +181,6 @@ const addTypecellModuleToRuntime = async (
       "utf-8"
     );
   } else {
-    debugger;
     content = await (
       await config.fetcher(
         process.env.PUBLIC_URL + "/types/" + typecellPath + "/" + path


### PR DESCRIPTION
Remove a `debugger;` statement and disable react runtime error reporting, because the page-filling overlay is currently very annoying.