### PR TITLE
fix mousehandling

### DIFF
--- a/packages/editor/src/runtime/executor/executionHosts/sandboxed/SandboxedExecutionHost.tsx
+++ b/packages/editor/src/runtime/executor/executionHosts/sandboxed/SandboxedExecutionHost.tsx
@@ -148,7 +148,7 @@ export default class SandboxedExecutionHost
       moduleManager.forwarder.dispose();
       this.moduleManagers.delete(moduleName);
     },
-    mouseLeave: (id: string) => {
+    mouseLeave: () => {
       this.enablePointerEvents();
     },
     setDimensions: (

--- a/packages/editor/src/runtime/executor/executionHosts/sandboxed/iframesandbox/FrameConnection.ts
+++ b/packages/editor/src/runtime/executor/executionHosts/sandboxed/iframesandbox/FrameConnection.ts
@@ -95,9 +95,9 @@ export class FrameConnection extends lifecycle.Disposable {
     this.connectionMethods!.setDimensions(path, dimensions);
   }
 
-  public mouseLeave(path: string) {
+  public mouseLeave() {
     console.log("mouseLeave");
-    this.connectionMethods!.mouseLeave(path);
+    this.connectionMethods!.mouseLeave();
   }
 
   private methods = {


### PR DESCRIPTION
This fixes the handling of mouse events by relying the "hand over" between iframe and parent window on mousemove, instead of mouseleave events