### PR TITLE
First local run: add supabase to instructions & improve shebang

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,10 @@ To run the project, open the command line in the project's root directory and en
     # Initial build of all packages required by the main editor project
     npm run build
 
+    # Start supabase
+    npm run start:supabase
+    # to stop docker containers later, run: npm run stop:supabase
+
     # Start the local server
     npm run start:server
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "start-react": "npm run start --workspace=packages/editor",
     "start:preview": "npm run preview --workspace=packages/editor",
     "start:server": "npm run dev --workspace=packages/server",
+    "start:supabase": "npm run start:supabase --workspace=packages/server",
+    "stop:supabase": "npm run stop:supabase --workspace=packages/server",
     "prepublishOnly": "npm run test && npm run build"
   },
   "overrides": {

--- a/packages/server/supabase.sh
+++ b/packages/server/supabase.sh
@@ -1,7 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # because we don't want to check in the secrets (even though they are staging)
 # we have to source them from a local file for config.toml to work and then run the supabase command
 # only necessary for local development, as github actions will have the secrets in env already
+if ! test -f .env.local; then
+    cp .env.local.example .env.local
+fi
 source .env.local
 export TYPECELL_GOOGLE_OAUTH_SECRET
 export TYPECELL_GITHUB_OAUTH_SECRET


### PR DESCRIPTION
What I had to change in order to run locally:
- start supabase (was not part of CONTRIBUTING.md instructions)
- modify supabase.sh to
  - initialize `.env.local`    
  - use a [more generic shebang](https://stackoverflow.com/a/16365367) that supports OSes where bash is not in the default location (NixOS in my case)